### PR TITLE
Use new xtd enum format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# build folders
+build
+build*
+cmake-build*
+
+# macOS files
+.DS_Store
+
+# Windows files
+Thumbs.db
+
+# CLion files
+.idea
+
+# Visual Studio files
+.vs
+
+# Visual Studio Code files
+.vscode
+
+# Qt user config make files
+CMakeLists.txt.user
+*.pro.user
+
+# Visual Studio user config cmake files
+CMakeSettings.json

--- a/src/enum_stringifier_form/enum_parser.hpp
+++ b/src/enum_stringifier_form/enum_parser.hpp
@@ -66,7 +66,7 @@ struct enum_parser
         else // if it's a [enum_member] only
         {
           // Pop ',' at the end if available
-          if (line.back() == ',') line.remove(line.size() - 1);
+          if (line.back() == ',') line = line.remove(line.size() - 1);
 
           // now the line itself becomes the [enum_member]
           std::pair<ustring, std::optional<ustring>> value{ line.trim(), std::nullopt };

--- a/src/enum_stringifier_form/enum_parser.hpp
+++ b/src/enum_stringifier_form/enum_parser.hpp
@@ -22,8 +22,16 @@ struct enum_parser
       if (line.starts_with("{")) continue; //  skip brackets opening {
       if (line.starts_with("}")) continue; //  skip brackets closing }
 
+      if (line.starts_with("namespace"))
+      {
+        // extract name which is expected to be the next thing after "enum class"
+        auto name_begin_idx = line.last_index_of("namespace") + std::strlen("namespace");
+        auto name_end_idx = line.last_index_of('{') - name_begin_idx;
+        if (name_end_idx == ustring::npos) name_end_idx = line.size() - 1; // '{' can be at the next line
+        namespaces.push_back(line.substr(name_begin_idx, name_end_idx).trim()); // extract enum class's name
+      }
       // If we're at the beginning of an enum class
-      if (line.starts_with("enum class"))
+      else if (line.starts_with("enum class"))
       {
         // extract name which is expected to be the next thing after "enum class"
         auto name_begin_idx = line.last_index_of("enum class") + std::strlen("enum class");
@@ -67,7 +75,10 @@ struct enum_parser
       }
     }
   }
+  
+  ustring name_with_namespace() const {return ustring::join("::", namespaces) + (namespaces.size() ? "::" : "") + name;}
 
+  std::vector<ustring> namespaces; // enum name
   ustring name; // enum name
   std::vector<std::pair<ustring, std::optional<ustring>>> values; // enum values
 };

--- a/src/enum_stringifier_form/enum_stringifier_form.cpp
+++ b/src/enum_stringifier_form/enum_stringifier_form.cpp
@@ -45,30 +45,26 @@ xtd::ustring enum_stringifier_form::stringify_enum_str(const xtd::ustring& enum_
   std::unique_ptr<enum_parser> enum_parser_ptr(new enum_parser(enum_str));
 
   std::ostringstream ostream_oss{};
-  std::ostringstream wostream_oss{};
 
-  ostream_oss << "inline std::ostream& operator<<(std::ostream& os, const " << enum_parser_ptr->name << " value) { return os << to_string(value, { ";
-  wostream_oss << "inline std::wostream& operator<<(std::wostream& os, const " << enum_parser_ptr->name << " value) { return os << to_string(value, { ";
+  ostream_oss << "template<> struct xtd::enum_register<" << enum_parser_ptr->name_with_namespace() << "> {" << std::endl
+  << "  explicit operator auto() const {return xtd::enum_collection<" << enum_parser_ptr->name_with_namespace() << "> {";
   for (std::size_t i = 0; i < enum_parser_ptr->values.size(); ++i)
   {
     const auto& [enum_member, value] = enum_parser_ptr->values[i];
     //{progress_box_options::none, "none"},
-    ostream_oss << '{' << enum_parser_ptr->name << "::" << enum_member << ", \"" << enum_member << "\"}";
-    wostream_oss << '{' << enum_parser_ptr->name << "::" << enum_member << ", L\"" << enum_member << "\"}";
+    ostream_oss << '{' << enum_parser_ptr->name_with_namespace() << "::" << enum_member << ", \"" << enum_member << "\"}";
     if (i != enum_parser_ptr->values.size() - 1)
     {
       ostream_oss << ", ";
-      wostream_oss << ", ";
     }
     else
     {
-      ostream_oss << "}); }";
-      wostream_oss << "}); }";
+      ostream_oss << "};}" << std::endl << "};";
     }
     //{progress_box_options::none, L"none"},
   }
 
-  return ostream_oss.str() + '\n' + wostream_oss.str();
+  return ostream_oss.str();
 }
 catch (const std::exception& e)
 {

--- a/src/main_form.cpp
+++ b/src/main_form.cpp
@@ -14,7 +14,7 @@ main_form::main_form() {
 	// 
 	static std::vector<std::unique_ptr<button>> buttons{};
 	std::int32_t yoffset = 10;
-	std::int32_t xoffset = 10;
+	//std::int32_t xoffset = 10;
 	for(const auto& v : m_tools_menu_item_options.menu_items())
 	{
 		std::unique_ptr<button> btn{ new button() };


### PR DESCRIPTION
Hello,

* I have modified your project to generate the new registration of enumeration format in xtd.
* I took the opportunity to correct an error on the deletion of the ',' at the end of the line. (unlike std::string, xtd::ustring is immutable, so the `xtd::string::remove` method does not modify the variable but returns a new instance of xtd::string).
* I commented out an unused variable that was causing a warning.

Have a nice day,
Gammasoft